### PR TITLE
RTD: some fixes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  apt_packages:
+    - graphviz
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,3 +11,7 @@ python:
       path: .
       extra_requirements:
         - docs
+
+
+sphinx:
+  fail_on_warning: true

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,4 +51,4 @@ html_theme = 'sphinx_book_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []


### PR DESCRIPTION
This PR enables errors on warnings for sphinx, such that we'll be informed about errors in the documentation in the future.

It also fixes existing errors, namely:
* the `graphviz` apt-package was missing (this is not installed automatically via pip)
* the configuration stated there is a static folder, but there hasn't been any