### PR TITLE
cfgrib dependency: add minimum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(),
     install_requires=[
-        "cfgrib",
+        "cfgrib>=0.9.9.0"",  # previous versions create a cffi error on index
         "eccodes",
         "numcodecs",
         "numpy",


### PR DESCRIPTION
`cfgrib` below 0.9.9.0 errors with
```
TypeError: initializer for ctype 'grib_handle *' must be a cdata pointer, not int
```