### PR TITLE
better support for grid definitions

### DIFF
--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -10,6 +10,7 @@ import eccodes
 import numpy as np
 
 from .magician import Magician
+from . import gridutils as gu
 
 import logging
 
@@ -285,7 +286,7 @@ def scan_gribfile(filelike, **kwargs):
                "shape": [s],
             },
            "extra": {k: arrays_to_list(m.get(k, None)) for k in (
-                EXTRA_PARAMETERS + cfgrib.dataset.GRID_TYPE_MAP.get(m["gridType"], []))},
+                EXTRA_PARAMETERS + gu.params_for_gridType(m["gridType"]))},
            **kwargs
            }
 

--- a/gribscan/gridutils.py
+++ b/gribscan/gridutils.py
@@ -1,0 +1,49 @@
+import numpy as np
+from scipy.special import roots_legendre
+
+
+class GribGrid:
+    _subclasses = []
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._subclasses.append(cls)
+
+
+class GaussianReduced(GribGrid):
+    gridType = "reduced_gg"
+    params = ["pl"]
+
+    @classmethod
+    def compute_coords(cls, pl):
+        lons = np.concatenate([np.linspace(0, 360, nl, endpoint=False) for nl in pl])
+        single_lats = np.rad2deg(-np.arcsin(roots_legendre(len(pl))[0]))
+        lats = np.concatenate([[lat]*nl for nl, lat in zip(pl, single_lats)])
+        return {"lon": lons, "lat": lats}
+
+
+class LatLonReduced(GribGrid):
+    gridType = "reduced_ll"
+    params = ["pl"]
+
+    @classmethod
+    def compute_coords(cls, pl):
+        lons = np.concatenate([np.linspace(0, 360, nl, endpoint=False) for nl in pl])
+        single_lats = np.linspace(90, -90, len(pl), endpoint=True)
+        lats = np.concatenate([[lat]*nl for nl, lat in zip(pl, single_lats)])
+        return {"lon": lons, "lat": lats}
+
+
+grids = {g.gridType: g for g in GribGrid._subclasses}
+
+
+def params_for_gridType(gridType):
+    if gridType in grids:
+        return grids[gridType].params
+    else:
+        return []
+
+
+def varinfo2coords(varinfo):
+    grid = grids[varinfo["attrs"]["gridType"]]
+    return grid.compute_coords(**{k: varinfo["extra"][k] for k in grid.params})

--- a/gribscan/magician.py
+++ b/gribscan/magician.py
@@ -1,6 +1,7 @@
 import numpy as np
-from scipy.special import roots_legendre
 import numcodecs
+
+from .gridutils import varinfo2coords
 
 class MagicianBase:
     def variable_hook(self, key, info):
@@ -60,13 +61,6 @@ class Magician(MagicianBase):
         return attrs, coords, {}, [name], None
 
 
-def make_gaussian_reduced(pl):
-    lons = np.concatenate([np.linspace(0, 360, nl, endpoint=False) for nl in pl])
-    single_lats = np.rad2deg(-np.arcsin(roots_legendre(len(pl))[0]))
-    lats = np.concatenate([[lat]*nl for nl, lat in zip(pl, single_lats)])
-    return lons, lats
-
-
 class IFSMagician(MagicianBase):
     varkeys = "param", "levtype"
     dimkeys = "posix_time", "level"
@@ -122,9 +116,7 @@ class IFSMagician(MagicianBase):
 
     def extra_coords(self, varinfo):
         v0 = next(iter(varinfo.values()))
-        pl = v0["extra"]["pl"]
-        lons, lats = make_gaussian_reduced(pl)
-        return {"lon": lons, "lat": lats}
+        return varinfo2coords(v0)
 
     def m2dataset(self, meta):
         return "atm3d" if meta["attrs"]["typeOfLevel"].startswith("isobaricInhPa") else "atm2d"

--- a/gribscan/magician.py
+++ b/gribscan/magician.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.special import roots_legendre
 import numcodecs
 
 class MagicianBase:
@@ -60,8 +61,8 @@ class Magician(MagicianBase):
 
 
 def make_gaussian_reduced(pl):
-    lons = np.concatenate([np.linspace(0, 360, nl) for nl in pl])
-    single_lats = np.linspace(90, -90, len(pl), endpoint=False) - (2 * 180 / len(pl))
+    lons = np.concatenate([np.linspace(0, 360, nl, endpoint=False) for nl in pl])
+    single_lats = np.rad2deg(-np.arcsin(roots_legendre(len(pl))[0]))
     lats = np.concatenate([[lat]*nl for nl, lat in zip(pl, single_lats)])
     return lons, lats
 


### PR DESCRIPTION
This PR tries to build an extensible method for implementing coordinates for grids which are explicitly defined in GRIB messages. Future extensions would only have to add a new `GribGrid` to `gridutils` which would then be picked up by the indexer as well as the magicians.