### PR TITLE
Remove explicit registration of codecs

### DIFF
--- a/gribscan/aeccodec.py
+++ b/gribscan/aeccodec.py
@@ -174,10 +174,3 @@ class AECCodec(numcodecs.abc.Codec):
             return out
         else:
             return b''.join(outlist)
-
-def register():
-    numcodecs.register_codec(AECCodec, "aec")
-
-register()
-
-__all__ = ["AECCodec", "register"]

--- a/gribscan/rawgribcodec.py
+++ b/gribscan/rawgribcodec.py
@@ -23,9 +23,3 @@ class RawGribCodec(numcodecs.abc.Codec):
             return ndarray_copy(data, out)
         else:
             return data
-
-def register():
-    numcodecs.register_codec(RawGribCodec, "rawgrib")
-    numcodecs.register_codec(RawGribCodec)
-
-register()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         "cfgrib>=0.9.9.0",  # previous versions create a cffi error on index
         "eccodes",
-        "numcodecs",
+        "numcodecs>=0.10.0",
         "numpy",
     ],
     extras_require={


### PR DESCRIPTION
With the release of `numcodecs>=0.10.0` entrypoints can be used.

This fixes #1