### PR TITLE
generate consolidated metadata

### DIFF
--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -446,6 +446,19 @@ def build_refs(messages, global_attrs, coords, varinfo, magician):
 
     return refs
 
+def is_zarr_key(key):
+    return key.endswith(".zarray") or key.endswith(".zgroup") or key.endswith(".zattrs")
+
+def consolidate_metadata(refs):
+    return json.dumps({
+        "zarr_consolidated_format": 1,
+        "metadata": {
+            key: json.loads(value)
+            for key, value in refs.items()
+            if is_zarr_key(key)
+        }
+    })
+
 def prepend_path(refs, prefix):
     """Prepend a path-prefix to all target filenames in a given reference filesystem."""
     return {k: [prefix + target[0]] + target[1:] if isinstance(target, list) else target
@@ -467,6 +480,7 @@ def grib_magic(filenames, magician=None, global_prefix=""):
     for dataset, messages in messages_by_dataset.items():
         global_attrs, coords, varinfo = inspect_grib_indices(messages, magician)
         refs = build_refs(messages, global_attrs, coords, varinfo, magician)
+        refs[".zmetadata"] = consolidate_metadata(refs)
         refs_by_dataset[dataset] = prepend_path(refs, global_prefix)
 
     return refs_by_dataset

--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -447,7 +447,7 @@ def build_refs(messages, global_attrs, coords, varinfo, magician):
     return refs
 
 def is_zarr_key(key):
-    return key.endswith(".zarray") or key.endswith(".zgroup") or key.endswith(".zattrs")
+    return key.endswith((".zarray", ".zgroup", ".zattrs"))
 
 def consolidate_metadata(refs):
     return json.dumps({


### PR DESCRIPTION
This PR adds consolidated metadata to gribscan-reference filesystems.

This may speed up loading slightly (directory structure does not have to be built), but this probably won't be much of a difference, as the entire JSON has to be parsed anyways.

The main reason for this change is convenience: with embedded consolidated metadata, `xr.open_zarr` won't complain anymore that metadata is missing and loading might be slow.