### PR TITLE
Add support for Harmonie's rotated grids (`rotated_ll`)

### DIFF
--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -134,6 +134,7 @@ EXTRA_PARAMETERS = [
     "timeRangeIndicator",
     "P1",
     "P2",
+    "latitudeOfFirstGridPointInDegrees"
 ]
 
 production_template_numbers = {
@@ -227,6 +228,14 @@ def get_time_offset(gribmessage, lean_towards="end"):
             offset += int(gribmessage["P1"]) * unit
         elif timeRangeIndicator == 1:
             pass
+        elif timeRangeIndicator in [2, 4]:
+            # Product with a valid time ranging between reference time + P1 and
+            # reference time + P2 
+            unit = time_range_units[
+                int(gribmessage.get("indicatorOfUnitOfTimeRange", 255))
+            ]
+            offset += int(gribmessage["P1"]) * unit
+
         elif timeRangeIndicator == 10:
             unit = time_range_units[
                 int(gribmessage.get("indicatorOfUnitOfTimeRange", 255))

--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -134,7 +134,6 @@ EXTRA_PARAMETERS = [
     "timeRangeIndicator",
     "P1",
     "P2",
-    "latitudeOfFirstGridPointInDegrees",
 ]
 
 production_template_numbers = {

--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -134,7 +134,7 @@ EXTRA_PARAMETERS = [
     "timeRangeIndicator",
     "P1",
     "P2",
-    "latitudeOfFirstGridPointInDegrees"
+    "latitudeOfFirstGridPointInDegrees",
 ]
 
 production_template_numbers = {
@@ -230,7 +230,7 @@ def get_time_offset(gribmessage, lean_towards="end"):
             pass
         elif timeRangeIndicator in [2, 4]:
             # Product with a valid time ranging between reference time + P1 and
-            # reference time + P2 
+            # reference time + P2
             unit = time_range_units[
                 int(gribmessage.get("indicatorOfUnitOfTimeRange", 255))
             ]

--- a/gribscan/gridutils.py
+++ b/gribscan/gridutils.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.special import roots_legendre
 from .rotated_grid import rot_to_reg
 
+
 class GribGrid:
     _subclasses = []
 
@@ -36,11 +37,19 @@ class LatLonReduced(GribGrid):
 
 class LatLonRotated(GribGrid):
     gridType = "rotated_ll"
-    params = ["Ni", "Nj", "latitudeOfFirstGridPointInDegrees", "longitudeOfFirstGridPointInDegrees", "latitudeOfLastGridPointInDegrees", "longitudeOfLastGridPointInDegrees", "latitudeOfSouthernPoleInDegrees", "longitudeOfSouthernPoleInDegrees"]
+    params = [
+        "Ni",
+        "Nj",
+        "latitudeOfFirstGridPointInDegrees",
+        "longitudeOfFirstGridPointInDegrees",
+        "latitudeOfLastGridPointInDegrees",
+        "longitudeOfLastGridPointInDegrees",
+        "latitudeOfSouthernPoleInDegrees",
+        "longitudeOfSouthernPoleInDegrees",
+    ]
 
     @classmethod
     def compute_coords(cls, **kwargs):
-        
         Ni = kwargs["Ni"]
         Nj = kwargs["Nj"]
         latFirst = kwargs["latitudeOfFirstGridPointInDegrees"]
@@ -56,15 +65,7 @@ class LatLonRotated(GribGrid):
 
         lons, lats = rot_to_reg(lonPole, latPole, lons, lats)
 
-        # import xarray as xr
-        # XXX: big hack, we need to actually parse the grid here, I loaded it with pyg2p instead...
-        # ds_grid = xr.open_dataset("/home/lcd/sample/sample/griddump.nc")
-        # import ipdb
-        # ipdb.set_trace()
-        
-        
         return {"lon": lons.flatten(), "lat": lats.flatten()}
-        # return {"lon": lons.tolist(), "lat": lats.tolist()}
 
 
 grids = {g.gridType: g for g in GribGrid._subclasses}
@@ -78,6 +79,5 @@ def params_for_gridType(gridType):
 
 
 def varinfo2coords(varinfo):
-    print(varinfo["extra"])
     grid = grids[varinfo["attrs"]["gridType"]]
     return grid.compute_coords(**{k: varinfo["extra"][k] for k in grid.params})

--- a/gribscan/gridutils.py
+++ b/gribscan/gridutils.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.special import roots_legendre
-
+from .rotated_grid import rot_to_reg
 
 class GribGrid:
     _subclasses = []
@@ -34,6 +34,39 @@ class LatLonReduced(GribGrid):
         return {"lon": lons, "lat": lats}
 
 
+class LatLonRotated(GribGrid):
+    gridType = "rotated_ll"
+    params = ["Ni", "Nj", "latitudeOfFirstGridPointInDegrees", "longitudeOfFirstGridPointInDegrees", "latitudeOfLastGridPointInDegrees", "longitudeOfLastGridPointInDegrees", "latitudeOfSouthernPoleInDegrees", "longitudeOfSouthernPoleInDegrees"]
+
+    @classmethod
+    def compute_coords(cls, **kwargs):
+        
+        Ni = kwargs["Ni"]
+        Nj = kwargs["Nj"]
+        latFirst = kwargs["latitudeOfFirstGridPointInDegrees"]
+        latLast = kwargs["latitudeOfLastGridPointInDegrees"]
+        lonFirst = kwargs["longitudeOfFirstGridPointInDegrees"]
+        lonLast = kwargs["longitudeOfLastGridPointInDegrees"]
+        latPole = kwargs["latitudeOfSouthernPoleInDegrees"]
+        lonPole = kwargs["longitudeOfSouthernPoleInDegrees"]
+
+        lons, lats = np.meshgrid(
+            np.linspace(lonFirst, lonLast, Ni), np.linspace(latFirst, latLast, Nj)
+        )
+
+        lons, lats = rot_to_reg(lonPole, latPole, lons, lats)
+
+        # import xarray as xr
+        # XXX: big hack, we need to actually parse the grid here, I loaded it with pyg2p instead...
+        # ds_grid = xr.open_dataset("/home/lcd/sample/sample/griddump.nc")
+        # import ipdb
+        # ipdb.set_trace()
+        
+        
+        return {"lon": lons.flatten(), "lat": lats.flatten()}
+        # return {"lon": lons.tolist(), "lat": lats.tolist()}
+
+
 grids = {g.gridType: g for g in GribGrid._subclasses}
 
 
@@ -45,5 +78,6 @@ def params_for_gridType(gridType):
 
 
 def varinfo2coords(varinfo):
+    print(varinfo["extra"])
     grid = grids[varinfo["attrs"]["gridType"]]
     return grid.compute_coords(**{k: varinfo["extra"][k] for k in grid.params})

--- a/gribscan/magician.py
+++ b/gribscan/magician.py
@@ -99,6 +99,8 @@ class IFSMagician(MagicianBase):
             "attrs": {
                 **info["attrs"],
                 "coordinates": "lon lat",
+                "Ni": info["extra"]["Ni"],
+                "Nj": info["extra"]["Nj"],
             },
         }
 

--- a/gribscan/magician.py
+++ b/gribscan/magician.py
@@ -99,6 +99,78 @@ class IFSMagician(MagicianBase):
             "attrs": {
                 **info["attrs"],
                 "coordinates": "lon lat",
+            },
+        }
+
+    def coords_hook(self, name, coords):
+        dims = [name]
+        attrs = {}
+        compressor = numcodecs.Blosc("zstd")
+        if "time" in name:
+            attrs = {
+                "units": "seconds since 1970-01-01T00:00:00",
+                "calendar": "proleptic_gregorian",
+            }
+        elif name == "lat":
+            dims = ["value"]
+            attrs = {
+                "long_name": "latitude",
+                "units": "degrees_north",
+                "standard_name": "latitude",
+            }
+        elif name == "lon":
+            dims = ["value"]
+            attrs = {
+                "long_name": "longitude",
+                "units": "degrees_east",
+                "standard_name": "longitude",
+            }
+        return attrs, coords, {}, dims, compressor
+
+    def extra_coords(self, varinfo):
+        v0 = next(iter(varinfo.values()))
+        return varinfo2coords(v0)
+
+    def m2dataset(self, meta):
+        return (
+            "atm3d"
+            if meta["attrs"]["typeOfLevel"].startswith("isobaricInhPa")
+            else "atm2d"
+        )
+
+
+class HarmonieMagician(MagicianBase):
+    varkeys = "param", "levtype"
+    dimkeys = "posix_time", "level"
+
+    def globals_hook(self, global_attrs):
+        history = global_attrs.get("history", "")
+        if len(history) > 0 and not history.endswith("\n"):
+            history = history + "\r\n"
+        history += (
+            "🪄🧙‍♂️🔮 magic dataset assembly provided by gribscan.HarmonieMagician\r\n"
+        )
+        return {**global_attrs, "history": history}
+
+    def variable_hook(self, key, info):
+        param, levtype = key
+        name = param
+        dims = info["dims"]
+
+        if levtype == "generalVertical":
+            name = param + "half" if param == "zg" else param
+            dims = tuple("halflevel" if dim == "level" else dim for dim in dims)
+        if levtype == "generalVerticalLayer":
+            dims = tuple("fulllevel" if dim == "level" else dim for dim in dims)
+        dims = tuple("time" if dim == "posix_time" else dim for dim in dims)
+
+        return {
+            "dims": dims,
+            "name": name,
+            "data_dims": ["value"],
+            "attrs": {
+                **info["attrs"],
+                "coordinates": "lon lat",
                 "Ni": info["extra"]["Ni"],
                 "Nj": info["extra"]["Nj"],
             },
@@ -144,4 +216,5 @@ class IFSMagician(MagicianBase):
 MAGICIANS = {
     "monsoon": Magician,
     "ifs": IFSMagician,
+    "harmonie": HarmonieMagician,
 }

--- a/gribscan/rotated_grid.py
+++ b/gribscan/rotated_grid.py
@@ -78,6 +78,7 @@ def rot_to_reg(pole_lon, pole_lat, lon, lat):
 
     return lon2, lat2
 
+
 def get_gids(gribfile: str, TextIOWrapper: bool = False) -> list:
     """Get GribIDs (gid) for all the messages in one gribfile
 

--- a/gribscan/rotated_grid.py
+++ b/gribscan/rotated_grid.py
@@ -1,0 +1,151 @@
+from __future__ import division
+
+import numpy as np
+import eccodes as ec
+
+pi = np.pi
+rad = pi / 180.0
+radinv = 1.0 / rad
+
+
+def rot_to_reg(pole_lon, pole_lat, lon, lat):
+    """Rotates from rotated grid to regular grid
+
+    Parameters
+    ----------
+    pole_lon : float
+        Longitude of pole in degrees
+    pole_lat : float
+        Latitude of pole in degrees
+    lon : float, list
+        Longitudes of points in grid. Can also be a single point.
+    lat : float, list
+        Latitudes of points in grid. Can also be a single point.
+
+    Returns
+    -------
+    lon1 : float, list
+        Longitudes of regular grid. Same shape as input.
+    lat1 : float, list
+        Latitudes  of regular grid. Same shape as input.
+    """
+    sin_pole = np.sin(rad * (pole_lat + 90.0))
+    cos_pole = np.cos(rad * (pole_lat + 90.0))
+
+    sin_lon = np.sin(rad * lon)
+    cos_lon = np.cos(rad * lon)
+    sin_lat = np.sin(rad * lat)
+    cos_lat = np.cos(rad * lat)
+
+    lat_tmp = cos_pole * sin_lat + sin_pole * cos_lat * cos_lon
+
+    try:
+        lat_tmp[np.where(lat_tmp < -1.0)] = -1.0
+        lat_tmp[np.where(lat_tmp > 1.0)] = 1.0
+    except TypeError:
+        if lat_tmp < -1.0:
+            lat_tmp = -1.0
+        if lat_tmp > 1.0:
+            lat_tmp = 1.0
+
+    lat2 = np.arcsin(lat_tmp) * radinv
+
+    cos_lat2 = np.cos(lat2 * rad)
+
+    cos_tmp = (cos_pole * cos_lat * cos_lon - sin_pole * sin_lat) / cos_lat2
+
+    try:
+        cos_tmp[np.where(cos_tmp < -1.0)] = -1.0
+        cos_tmp[np.where(cos_tmp > 1.0)] = 1.0
+    except TypeError:
+        if cos_tmp < -1.0:
+            cos_tmp = -1.0
+        if cos_tmp > 1.0:
+            cos_tmp = 1.0
+
+    tmp_sin_lon = cos_lat * sin_lon / cos_lat2
+    tmp_cos_lon = np.arccos(cos_tmp) * radinv
+
+    try:
+        tmp_cos_lon[np.where(tmp_sin_lon < 0.0)] = -tmp_cos_lon[
+            np.where(tmp_sin_lon < 0.0)
+        ]
+    except IndexError:
+        if tmp_sin_lon < 0.0:
+            tmp_cos_lon = -tmp_cos_lon
+
+    lon2 = tmp_cos_lon + pole_lon
+
+    return lon2, lat2
+
+def get_gids(gribfile: str, TextIOWrapper: bool = False) -> list:
+    """Get GribIDs (gid) for all the messages in one gribfile
+
+    Parameters
+    ----------
+    gribfile : str
+        path to gribfile
+    TextIOWrapper : bool
+        if file is open send the object instead and set TextIOWrapper to True
+
+    Returns
+    -------
+    list
+        list of grib-ids
+    """
+
+    if not TextIOWrapper:
+        f = open(gribfile, "rb")
+        msg_count = ec.codes_count_in_file(f)
+        gids = [ec.codes_grib_new_from_file(f) for i in range(msg_count)]
+        f.close()
+    else:
+        # gribfile has already been opened into a TextIOWrapper in this case
+        msg_count = ec.codes_count_in_file(gribfile)
+        gids = np.zeros(msg_count, dtype=int)
+        for i in range(msg_count):
+            gids[i] = ec.codes_grib_new_from_file(gribfile)
+
+    return gids
+
+
+def get_latlons(gribfile: str) -> tuple:
+    """Get latitudes and longitudes from file. Uses pygrib as
+    eccodes have no easy interface for that.
+
+    Parameters
+    ----------
+    gribfile : str
+        Path to gribfile
+
+    Returns
+    -------
+    tuple
+        tuple of latitudes, longitudes
+    """
+
+    gids = get_gids(gribfile)
+    gid = gids[0]
+    Ni = ec.codes_get(gid, "Ni")
+    Nj = ec.codes_get(gid, "Nj")
+
+    latFirst = ec.codes_get(gid, "latitudeOfFirstGridPointInDegrees")
+    latLast = ec.codes_get(gid, "latitudeOfLastGridPointInDegrees")
+    lonFirst = ec.codes_get(gid, "longitudeOfFirstGridPointInDegrees")
+    lonLast = ec.codes_get(gid, "longitudeOfLastGridPointInDegrees")
+
+    latPole = ec.codes_get(gid, "latitudeOfSouthernPoleInDegrees")
+    lonPole = ec.codes_get(gid, "longitudeOfSouthernPoleInDegrees")
+
+    gridType = ec.codes_get(gid, "gridType")
+
+    lons, lats = np.meshgrid(
+        np.linspace(lonFirst, lonLast, Ni), np.linspace(latFirst, latLast, Nj)
+    )
+
+    if gridType == "rotated_ll":
+        lons, lats = rot_to_reg(lonPole, latPole, lons, lats)
+    else:
+        raise NotImplementedError(gridType)
+
+    return lats, lons

--- a/gribscan/tools.py
+++ b/gribscan/tools.py
@@ -21,10 +21,7 @@ def create_index():
     args = parser.parse_args()
 
     if args.nprocs == 1:
-        import ipdb
-
-        with ipdb.launch_ipdb_on_exception():
-            [gribscan.write_index(source) for source in args.sources]
+        [gribscan.write_index(source) for source in args.sources]
     else:
         with mp.Pool(args.nprocs) as pool:
             pool.map(gribscan.write_index, args.sources)

--- a/gribscan/tools.py
+++ b/gribscan/tools.py
@@ -20,8 +20,13 @@ def create_index():
     )
     args = parser.parse_args()
 
-    with mp.Pool(args.nprocs) as pool:
-        pool.map(gribscan.write_index, args.sources)
+    if args.nprocs == 1:
+        import ipdb
+        with ipdb.launch_ipdb_on_exception():
+            [gribscan.write_index(source) for source in args.sources]
+    else:
+        with mp.Pool(args.nprocs) as pool:
+            pool.map(gribscan.write_index, args.sources)
 
 
 def build_dataset():
@@ -67,5 +72,7 @@ def build_dataset():
     )
 
     for dataset, ref in refs.items():
-        with open(f"{args.output}/{dataset}.json", "w") as indexfile:
+        fp = Path(f"{args.output}/{dataset}.json")
+        fp.parent.mkdir(exist_ok=True, parents=True)
+        with open(fp, "w") as indexfile:
             json.dump(ref, indexfile)

--- a/gribscan/tools.py
+++ b/gribscan/tools.py
@@ -22,6 +22,7 @@ def create_index():
 
     if args.nprocs == 1:
         import ipdb
+
         with ipdb.launch_ipdb_on_exception():
             [gribscan.write_index(source) for source in args.sources]
     else:


### PR DESCRIPTION
Thanks for creating this @d70-t!

There are quite a few things in this PR, but principally it is about adding support for parsing the rotated grid that [Harmonie](https://hirlam.github.io/HarmonieSystemDocumentation/dev/) uses. I'm happy to split this into smaller PRs too, but it would be great to have your thoughts on this :)

Specifically one thing I'd like to improve is how the variables currently end up with having dimensions of `(time, value)` rather than `(time,x,y)`. With this PR I am able to create the GRIB-file index-files and the gribscan json-collection like so:

![image](https://github.com/gribscan/gribscan/assets/2405019/29217ba9-ce66-4fc1-ba3a-ef41a64e189d)

I then manually add the `x` and `y` coordinates and unstack to get the variables to have the 2D shape in space:

![image](https://github.com/gribscan/gribscan/assets/2405019/a037a93e-ae70-4241-b5d9-e01848e9e4a6)

But this step wouldn't be needed if I didn't have to flatten the lat/lon coordinate variables in https://github.com/leifdenby/gribscan/blob/harmonie-rotated-grids/gribscan/gridutils.py#L68. Maybe the right thing to do here is return `x` and `y` as the *actual* coordinates here and the `lat` and `lon` would be a form of auxiliary dataset coordinates. What do you think? Would it be possible to have the x/y coordinate info stored in the json-files somehow?

I hope this makes sense :) This tool is going to be really great to work with Harmonie model output (and eventually being able to put that into a zarr-backed object store). Thanks again, I hope you're doing well!

PS. There are two minor tweaks to the code: 1) not using multiprocessing when only one cpu is requested when building the gribscan index and 2) automatically creating the parent directory if it is missing when creating the json-file for the entire dataset.

