### PR TITLE
Disable automatic prefix inspection

### DIFF
--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -566,7 +566,7 @@ def compress_extra_attributes(messages):
         mlast = m
 
 
-def grib_magic(filenames, magician=None, global_prefix=""):
+def grib_magic(filenames, magician=None, global_prefix=None):
     if magician is None:
         magician = Magician()
 
@@ -587,6 +587,9 @@ def grib_magic(filenames, magician=None, global_prefix=""):
         global_attrs, coords, varinfo = inspect_grib_indices(messages, magician)
         refs = build_refs(messages, global_attrs, coords, varinfo, magician)
         refs[".zmetadata"] = consolidate_metadata(refs)
-        refs_by_dataset[dataset] = prepend_path(refs, global_prefix)
+        if global_prefix is None:
+            refs_by_dataset[dataset] = refs
+        else:
+            refs_by_dataset[dataset] = prepend_path(refs, global_prefix)
 
     return refs_by_dataset

--- a/gribscan/tools.py
+++ b/gribscan/tools.py
@@ -88,9 +88,6 @@ def build_dataset():
     )
     args = parser.parse_args()
 
-    if args.prefix is None:
-        args.prefix = Path(args.indices[0]).parent.resolve().as_posix() + "/"
-
     magician = MAGICIANS[args.magician]()
 
     refs = gribscan.grib_magic(


### PR DESCRIPTION
This feature clashes when using the newly implemented sub-tree feature and not passing a global prefix explicitly.