### PR TITLE
Various fixes to handle ERA5

### DIFF
--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -91,18 +91,15 @@ def _split_file(f, skip=0):
     while f.tell() < size:
         logger.debug(f"extract part {part + 1}")
         start = f.tell()
-        indicator = f.read(16)
+        indicator = f.peek(16)
         if indicator[:4] != b"GRIB":
             logger.info(f"non-consecutive messages, searching for part {part + 1}")
-            f.seek(start)
             start = find_stream(f, b"GRIB")
-            indicator = f.read(16)
+            indicator = f.peek(16)
         if len(indicator) < 16:
             return
 
         grib_edition = indicator[7]
-
-        f.seek(start)
 
         if grib_edition == 1:
             part_size = int.from_bytes(indicator[4:7], "big")

--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -229,7 +229,7 @@ def get_time_offset(gribmessage, lean_towards="end"):
             offset += int(gribmessage["P1"]) * unit
         elif timeRangeIndicator == 1:
             pass
-        elif timeRangeIndicator == 3:
+        elif timeRangeIndicator in [2, 3]:
             unit = time_range_units[
                 int(gribmessage.get("indicatorOfUnitOfTimeRange", 255))
             ]
@@ -237,6 +237,11 @@ def get_time_offset(gribmessage, lean_towards="end"):
                 offset += int(gribmessage["P1"]) * unit
             elif lean_towards == "end":
                 offset += int(gribmessage["P2"]) * unit
+        elif timeRangeIndicator == 4:
+            unit = time_range_units[
+                int(gribmessage.get("indicatorOfUnitOfTimeRange", 255))
+            ]
+            offset += int(gribmessage["P2"]) * unit
         elif timeRangeIndicator == 10:
             unit = time_range_units[
                 int(gribmessage.get("indicatorOfUnitOfTimeRange", 255))

--- a/gribscan/magician.py
+++ b/gribscan/magician.py
@@ -99,6 +99,7 @@ class IFSMagician(MagicianBase):
             "attrs": {
                 **info["attrs"],
                 "coordinates": "lon lat",
+                "missingValue": 9999,
             },
         }
 


### PR DESCRIPTION
This PR
* implements missing time range indicators in GRIB1 messages
* makes the IFS magician overwrite the missing value with a hard-coded value of `9999`
* replaces backwards seeks with the peek function to reduce load on LUSTE file systems and infiniband