### PR TITLE
Fix building of references for fields without dimensions

### DIFF
--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -458,8 +458,11 @@ def build_refs(messages, global_attrs, coords, varinfo, magician):
         info = varinfo[key]
         cs = [coord[d] for d in info["dim_id"]]
         chunk_id = ".".join(
-            map(str, [coords_inv[d][c] for d, c in zip(info["dims"], cs)])
-        ) + ".0" * len(info["data_dims"])
+            itertools.chain(
+                map(str, [coords_inv[d][c] for d, c in zip(info["dims"], cs)]),
+                ["0"] * len(info["data_dims"])
+            )
+        )
         refs[info["name"] + "/" + chunk_id] = [
             msg["filename"],
             msg["_offset"],


### PR DESCRIPTION
The old implementatoin failed for variables that only had `data_dims` but no `dims`, e.g., time-invariant fields.