### PR TITLE
Citation cleanup

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,6 +3,7 @@ message: "If you use this software, please cite it as below."
 authors:
 - family-names: "Kölling"
   given-names: "Tobias"
+  orcid: "https://orcid.org/0009-0007-8742-2706"
 - family-names: "Kluft"
   given-names: "Lukas"
   orcid: "https://orcid.org/0000-0002-6533-3928"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-message: "If you use this software, please cite it as below."
+message: "If you use this software, please cite it using these metadata."
 authors:
 - family-names: "Kölling"
   given-names: "Tobias"
@@ -11,11 +11,13 @@ authors:
   given-names: "Thomas"
   orcid: "https://orcid.org/0000-0002-5468-575X"
 title: "gribscan"
-url: "https://github.com/gribscan/gribscan"
-keywords:    
-  - fsspec    
-  - grib    
-  - zarr    
-license: MIT    
+abstract: "Build indices and datasets from GRIB files."
+url: "https://gribscan.readthedocs.io"
+repository-code: "https://github.com/gribscan/gribscan"
+keywords:
+  - fsspec
+  - grib
+  - zarr
+license: MIT
 repository-code: "https://github.com/gribscan/gribscan"
 type: software


### PR DESCRIPTION
Some cleanup of the citation file, in preparation of a Zenodo publication (#35).

I took the abstract from this repositories description "Build indices and datasets from GRIB files.". Do we like that, or to we want something longer?