### PR TITLE
Time-axis improvements & EERIE Magician

### DIFF
--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -135,6 +135,7 @@ EXTRA_PARAMETERS = [
     "productDefinitionTemplateNumber",
     "N",
     "timeRangeIndicator",
+    "stepRange",
     "P1",
     "P2",
     "numberIncludedInAverage",
@@ -521,6 +522,7 @@ def build_refs(messages, global_attrs, coords, varinfo, magician):
         refs[info["name"] + "/.zattrs"] = json.dumps(
             {
                 **info["attrs"],
+                **info["extra"],
                 "_ARRAY_DIMENSIONS": list(info["dims"]) + list(info["data_dims"]),
             }
         )

--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -273,35 +273,35 @@ def get_time_offset(gribmessage, lean_towards="end"):
         except KeyError:
             return offset
         if options["forcastTime"]:
-            # print("forcastTime")
+            logger.info("forcastTime")
             unit = time_range_units[
                 int(gribmessage.get("indicatorOfUnitOfTimeRange", 255))
             ]
             offset += gribmessage.get("forecastTime", 0) * unit
         if options["timeRange"] and lean_towards == "end":
-            # print("timeRange, lean to end")
+            logger.info("timeRange, lean to end")
             unit = time_range_units[
                 int(gribmessage.get("indicatorOfUnitOfTimeRange", 255))
             ]
             offset += gribmessage.get("lengthOfTimeRange", 0) * unit
         if options["timeRange"] and lean_towards == "mid":
-            # print("timeRange, lean to mid")
+            logger.info("timeRange, lean to mid")
             unit = time_range_units[
                 int(gribmessage.get("indicatorOfUnitOfTimeRange", 255))
             ]
             offseti = gribmessage.get("lengthOfTimeRange", 0) * unit
             offseti_h = offseti / 3600
             if offseti_h < 24:
-                print('TimeRange: %.1f-hourly. Set time to middle of the interval by adding an offset of %.1f hours' % (offseti_h,offseti_h/2))
+                logger.info('TimeRange: %.1f-hourly. Set time to middle of the interval by adding an offset of %.1f hours' % (offseti_h,offseti_h/2))
                 offset += int(3600 * offseti_h / 2)
             elif offseti_h == 24:
-                print('TimeRange: daily. Set time to 12:00 by adding an offset of 12 hours')
+                logger.info('TimeRange: daily. Set time to 12:00 by adding an offset of 12 hours')
                 offset += int(3600 * 12)
             elif int(offseti_h/24) in [28,29,30,31]:
-                print('TimeRange: monthly. Set time to 12:00 at 15th of the month by adding an offset of 14.5 days')
+                logger.info('TimeRange: monthly. Set time to 12:00 at 15th of the month by adding an offset of 14.5 days')
                 offset += int(86400 * ( 14 + 1/2) )
             elif int(offseti_h/24) in [365,366]:
-                print('TimeRange: annual. Set time to 12:00 at 1st of July by removing an offset of 183.5 days from the end of the interval')
+                logger.info('TimeRange: annual. Set time to 12:00 at 1st of July by removing an offset of 183.5 days from the end of the interval')
                 offset += offseti - int(86400 * ( 183 + 1/2) )
             else:
                 raise ValueError(
@@ -310,7 +310,7 @@ def get_time_offset(gribmessage, lean_towards="end"):
                         )
                     )
         if options["timeRange"] and lean_towards == "start":
-            # print("timeRange, lean to start")
+            logger.info("timeRange, lean to start")
             # do nothing, offset is already at the start
             offset += 0
     return offset

--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -321,6 +321,7 @@ def scan_gribfile(filelike, **kwargs):
             "posix_time": m["time"] + get_time_offset(m),
             "domain": m["globalDomain"],
             "member": m.get("number", None),
+            "realization": m.get("realization", None),
             "time": f"{m['hour']:02d}{m['minute']:02d}",
             "date": f"{m['year']:04d}{m['month']:02d}{m['day']:02d}",
             "levtype": m.get("typeOfLevel", None),

--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -290,15 +290,18 @@ def get_time_offset(gribmessage, lean_towards="end"):
             ]
             offseti = gribmessage.get("lengthOfTimeRange", 0) * unit
             offseti_h = offseti / 3600
-            if offseti_h == 24:
+            if offseti_h < 24:
+                print('TimeRange: %.1f-hourly. Set time to middle of the interval by adding an offset of %.1f hours' % (offseti_h,offseti_h/2))
+                offset += int(3600 * offseti_h / 2)
+            elif offseti_h == 24:
                 print('TimeRange: daily. Set time to 12:00 by adding an offset of 12 hours')
                 offset += int(3600 * 12)
             elif int(offseti_h/24) in [28,29,30,31]:
                 print('TimeRange: monthly. Set time to 12:00 at 15th of the month by adding an offset of 14.5 days')
                 offset += int(86400 * ( 14 + 1/2) )
-            elif offseti_h < 24:
-                print('TimeRange: %i-hourly. Set time to middle of the interval by adding an offset of %.1f hours' % (offseti_h,offseti_h/2))
-                offset += int(3600 * offseti_h / 2)
+            elif int(offseti_h/24) in [365,366]:
+                print('TimeRange: annual. Set time to 12:00 at 1st of July by removing an offset of 183.5 days from the end of the interval')
+                offset += offseti - int(86400 * ( 183 + 1/2) )
             else:
                 raise ValueError(
                     'Trying to execute lean_towards="mid", but finding unexpected period length of %i hours. stepType: %s, step: %s, stepRange: %s' % (

--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -296,14 +296,14 @@ def get_time_offset(gribmessage, lean_towards="end"):
             elif int(offseti_h/24) in [28,29,30,31]:
                 print('TimeRange: monthly. Set time to 12:00 at 15th of the month by adding an offset of 14.5 days')
                 offset += int(86400 * ( 14 + 1/2) )
-            # elif offseti_h == 6:
             elif offseti_h < 24:
                 print('TimeRange: %i-hourly. Set time to middle of the interval by adding an offset of %.1f hours' % (offseti_h,offseti_h/2))
                 offset += int(3600 * offseti_h / 2)
             else:
-                # raise ValueError('Trying to execute lean_towards="mid", but finding unexpected period length of %i days' % offseti_day)
-                raise ValueError('Trying to execute lean_towards="mid", but finding unexpected period length of %i hours. stepType: %s, step: %s, stepRange: %s' % (
-                    offseti_h,gribmessage['stepType'],gribmessage['step'],gribmessage['stepRange'])
+                raise ValueError(
+                    'Trying to execute lean_towards="mid", but finding unexpected period length of %i hours. stepType: %s, step: %s, stepRange: %s' % (
+                        offseti_h,gribmessage['stepType'],gribmessage['step'],gribmessage['stepRange']
+                        )
                     )
         if options["timeRange"] and lean_towards == "start":
             # print("timeRange, lean to start")
@@ -319,7 +319,6 @@ def arrays_to_list(o):
         return o
 
 
-# def scan_gribfile(filelike, **kwargs):
 def scan_gribfile(filelike, lean_towards='end', **kwargs):
     for offset, size, grib_edition, data in _split_file(filelike):
         mid = eccodes.codes_new_from_message(data)
@@ -348,7 +347,6 @@ def scan_gribfile(filelike, lean_towards='end', **kwargs):
                 for k in ["discipline", "parameterCategory", "parameterNumber"]
             },
             "posix_time": m["time"] + get_time_offset(m,lean_towards=lean_towards),
-            # "posix_time": m["time"] + get_time_offset(m),
             "domain": m["globalDomain"],
             "member": m.get("number", None),
             "realization": m.get("realization", None),
@@ -374,9 +372,7 @@ def scan_gribfile(filelike, lean_towards='end', **kwargs):
         }
 
 
-# def write_index(gribfile, idxfile=None, outdir=None, force=False):
 def write_index(gribfile, idxfile=None, outdir=None, force=False, lean_towards='end'):
-    print(gribfile)
     p = pathlib.Path(gribfile)
     if outdir is None:
         outdir = p.parent
@@ -390,7 +386,6 @@ def write_index(gribfile, idxfile=None, outdir=None, force=False, lean_towards='
     # We need to use the gribfile (str) variable because Path() objects
     # collapse the "/./" notation used to denote subtrees.
     gen = scan_gribfile(open(p, "rb"), lean_towards=lean_towards, filename=gribfile)
-    # gen = scan_gribfile(open(p, "rb"), filename=gribfile)
 
     tempfile = idxfile.with_suffix(".index.partial")
     with open(tempfile, "w") as output_file:

--- a/gribscan/magician.py
+++ b/gribscan/magician.py
@@ -150,8 +150,8 @@ class IFSMagicianEERIE(IFSMagician):
     - makes ensemble "realization" axis (for "ed" class requires eccodes >= 2.36.1)
     '''
 
-    dimkeys = "referenceTime", "level", "realization"
-    # dimkeys = "posix_time", "level", "realization"
+    # dimkeys = "referenceTime", "level", "realization"
+    dimkeys = "posix_time", "level", "realization"
 
     def coords_hook(self, name, coords):
         dims = [name]

--- a/gribscan/magician.py
+++ b/gribscan/magician.py
@@ -148,7 +148,7 @@ class IFSMagicianEERIE(IFSMagician):
         - Time-processing by stepType (instant/accum/avg/min/max). 
         - Constant fields of surface geopotential & land-sea mask go into "atm2d_const.json".
         - Output on wave model (WAM) native grid (pre 49r1) goes into separate jsons with additional "_ll" suffix.
-    - This is intended to be used together with the n3ew get_time_offset option "mid", 
+    - This is intended to be used together with the new get_time_offset option "mid", 
         such that stepRange-based variables are now located towards the CENTER of the stepRange.
     '''
 

--- a/gribscan/magician.py
+++ b/gribscan/magician.py
@@ -142,15 +142,16 @@ class IFSMagician(MagicianBase):
 class IFSMagicianEERIE(IFSMagician):
     '''
     More differentiation on output files, for EERIE project
-    - split stepType instant/accum/avg/min/max
-    - make time-axis based on "referenceTime" not "posix_time" (assumes that time-axis in grib is NOT fc-type as initial_time + step)
-        NOT consistent with previous catalogues. where e.g. mean over Jan 2020 is indexed as 2020-02-01
-        NOW mean over Jan 2020 is indexed as 2020-01-01 (following convention of significanceOfReferenceTime=2)
-        (TODO: maybe possible to instead put an automatic option into get_time_offset to e.g. set offset=0 if gribmessage.get("significanceOfReferenceTime")==2
-    - makes ensemble "realization" axis (for "ed" class requires eccodes >= 2.36.1)
+    - introduces ensemble "realization" axis (for "ed" class requires eccodes >= 2.36.1). 
+        Only appears if processing more than one member.
+    - split jsons files by type: 
+        - Time-processing by stepType (instant/accum/avg/min/max). 
+        - Constant fields of surface geopotential & land-sea mask go into "atm2d_const.json".
+        - Output on wave model (WAM) native grid (pre 49r1) goes into separate jsons with additional "_ll" suffix.
+    - This is intended to be used together with the n3ew get_time_offset option "mid", 
+        such that stepRange-based variables are now located towards the CENTER of the stepRange.
     '''
 
-    # dimkeys = "referenceTime", "level", "realization"
     dimkeys = "posix_time", "level", "realization"
 
     def globals_hook(self, global_attrs):
@@ -191,75 +192,6 @@ class IFSMagicianEERIE(IFSMagician):
                 "standard_name": "longitude",
             }
         return attrs, coords, {}, dims, compressor
-    
-    def variable_hook(self, key, info):
-        param, levtype = key
-        name = param
-        dims = info["dims"]
-
-        if levtype == "generalVertical":
-            name = param + "half" if param == "zg" else param
-            dims = tuple("halflevel" if dim == "level" else dim for dim in dims)
-        if levtype == "generalVerticalLayer":
-            dims = tuple("fulllevel" if dim == "level" else dim for dim in dims)
-        dims = tuple("time" if "time" in dim.lower() else dim for dim in dims)
-
-        return {
-            "dims": dims,
-            "name": name,
-            "data_dims": ["value"],
-            "attrs": {
-                **info["attrs"],
-                "coordinates": "lon lat",
-                "missingValue": 9999,
-            },
-        }
-    
-    def m2dataset(self, meta):
-        # check for data dimensionality
-        if meta["attrs"]["typeOfLevel"].startswith("isobaricInhPa"): # 3D field
-            dim=3
-        else:
-            dim=2
-
-        if meta['attrs']['stepType'] == 'instant': # instantaneous
-            proc=""
-        elif meta['attrs']['stepType'] == 'accum': # accumulations
-            proc="_acc"
-        elif meta['attrs']['stepType'] == 'avg': # time-averaged 
-            proc="_avg"
-        elif meta['attrs']['stepType'] == 'min': # min
-            proc="_min"
-        elif meta['attrs']['stepType'] == 'max': # max
-            proc="_max"
-        else:
-            proc=""
-
-        # constant fields (surface geopotential & lsm)
-        if ( (meta['attrs']['paramId'] == 129) and (meta["level"] == 0) ) or (meta['attrs']['paramId'] == 172):
-            dim=2
-            proc="_const"
-            
-        # check for model grid
-        if meta['attrs']['gridType'] == "reduced_ll": # reduced lat-lon grid (wave model native, pre 49r1)
-            grid='_ll'
-        else:
-            grid=""
-
-        outstr = 'atm%id%s%s' % (dim,grid,proc)
-        return outstr
-
-class IFSMagicianEERIE_v1(IFSMagician):
-    '''
-    first iteration of Magician for EERIE project, less functionality than IFSMagicianEERIE
-    - Does NOT include time-axis based on "referenceTime"
-        consistent with previous catalogues, putting TimeRange data as time_start + TimeRange, e.g. mean over Jan 2020 is indexed as 2020-02-01
-    - Does NOT include realization-axis
-
-    - DOES split stepType instant/accum/avg/min/max
-    '''
-
-    dimkeys = "posix_time", "level"
 
     def m2dataset(self, meta):
         # check for data dimensionality
@@ -294,7 +226,7 @@ class IFSMagicianEERIE_v1(IFSMagician):
 
         outstr = 'atm%id%s%s' % (dim,grid,proc)
         return outstr
-    
+
 class EnsembleMagician(IFSMagician):
     varkeys = "param", "levtype"
     dimkeys = "posix_time", "level", "member"
@@ -319,6 +251,5 @@ MAGICIANS = {
     "monsoon": Magician,
     "ifs": IFSMagician,
     "ifseerie": IFSMagicianEERIE,
-    "ifseeriev1": IFSMagicianEERIE_v1,
     "enfo": EnsembleMagician,
 }

--- a/gribscan/magician.py
+++ b/gribscan/magician.py
@@ -163,7 +163,6 @@ class IFSMagicianEERIE(IFSMagician):
                 "calendar": "proleptic_gregorian",
             }
         elif name == "realization":
-            # dims = ["value"]
             attrs = {
                 "long_name": "realization",
                 "units": "",

--- a/gribscan/magician.py
+++ b/gribscan/magician.py
@@ -139,7 +139,155 @@ class IFSMagician(MagicianBase):
             else "atm2d"
         )
 
+class IFSMagicianEERIE(IFSMagician):
+    '''
+    More differentiation on output files, for EERIE project
+    - split stepType instant/accum/avg/min/max
+    - make time-axis based on "referenceTime" not "posix_time" (assumes that time-axis in grib is NOT fc-type as initial_time + step)
+        NOT consistent with previous catalogues. where e.g. mean over Jan 2020 is indexed as 2020-02-01
+        NOW mean over Jan 2020 is indexed as 2020-01-01 (following convention of significanceOfReferenceTime=2)
+        (TODO: maybe possible to instead put an automatic option into get_time_offset to e.g. set offset=0 if gribmessage.get("significanceOfReferenceTime")==2
+    - makes ensemble "realization" axis (for "ed" class requires eccodes >= 2.36.1)
+    '''
 
+    dimkeys = "referenceTime", "level", "realization"
+    # dimkeys = "posix_time", "level", "realization"
+
+    def coords_hook(self, name, coords):
+        dims = [name]
+        attrs = {}
+        compressor = numcodecs.Blosc("zstd")
+        if "time" in name:
+            attrs = {
+                "units": "seconds since 1970-01-01T00:00:00",
+                "calendar": "proleptic_gregorian",
+            }
+        elif name == "realization":
+            # dims = ["value"]
+            attrs = {
+                "long_name": "realization",
+                "units": "",
+                "standard_name": "realization",
+            }
+        elif name == "lat":
+            dims = ["value"]
+            attrs = {
+                "long_name": "latitude",
+                "units": "degrees_north",
+                "standard_name": "latitude",
+            }
+        elif name == "lon":
+            dims = ["value"]
+            attrs = {
+                "long_name": "longitude",
+                "units": "degrees_east",
+                "standard_name": "longitude",
+            }
+        return attrs, coords, {}, dims, compressor
+    
+    def variable_hook(self, key, info):
+        param, levtype = key
+        name = param
+        dims = info["dims"]
+
+        if levtype == "generalVertical":
+            name = param + "half" if param == "zg" else param
+            dims = tuple("halflevel" if dim == "level" else dim for dim in dims)
+        if levtype == "generalVerticalLayer":
+            dims = tuple("fulllevel" if dim == "level" else dim for dim in dims)
+        dims = tuple("time" if "time" in dim.lower() else dim for dim in dims)
+
+        return {
+            "dims": dims,
+            "name": name,
+            "data_dims": ["value"],
+            "attrs": {
+                **info["attrs"],
+                "coordinates": "lon lat",
+                "missingValue": 9999,
+            },
+        }
+    
+    def m2dataset(self, meta):
+        # check for data dimensionality
+        if meta["attrs"]["typeOfLevel"].startswith("isobaricInhPa"): # 3D field
+            dim=3
+        else:
+            dim=2
+
+        if meta['attrs']['stepType'] == 'instant': # instantaneous
+            proc=""
+        elif meta['attrs']['stepType'] == 'accum': # accumulations
+            proc="_acc"
+        elif meta['attrs']['stepType'] == 'avg': # time-averaged 
+            proc="_avg"
+        elif meta['attrs']['stepType'] == 'min': # min
+            proc="_min"
+        elif meta['attrs']['stepType'] == 'max': # max
+            proc="_max"
+        else:
+            proc=""
+
+        # constant fields (surface geopotential & lsm)
+        if ( (meta['attrs']['paramId'] == 129) and (meta["level"] == 0) ) or (meta['attrs']['paramId'] == 172):
+            dim=2
+            proc="_const"
+            
+        # check for model grid
+        if meta['attrs']['gridType'] == "reduced_ll": # reduced lat-lon grid (wave model native, pre 49r1)
+            grid='_ll'
+        else:
+            grid=""
+
+        outstr = 'atm%id%s%s' % (dim,grid,proc)
+        return outstr
+
+class IFSMagicianEERIE_v1(IFSMagician):
+    '''
+    first iteration of Magician for EERIE project, less functionality than IFSMagicianEERIE
+    - Does NOT include time-axis based on "referenceTime"
+        consistent with previous catalogues, putting TimeRange data as time_start + TimeRange, e.g. mean over Jan 2020 is indexed as 2020-02-01
+    - Does NOT include realization-axis
+
+    - DOES split stepType instant/accum/avg/min/max
+    '''
+
+    dimkeys = "posix_time", "level"
+
+    def m2dataset(self, meta):
+        # check for data dimensionality
+        if meta["attrs"]["typeOfLevel"].startswith("isobaricInhPa"): # 3D field
+            dim=3
+        else:
+            dim=2
+
+        if meta['attrs']['stepType'] == 'instant': # instantaneous
+            proc=""
+        elif meta['attrs']['stepType'] == 'accum': # accumulations
+            proc="_acc"
+        elif meta['attrs']['stepType'] == 'avg': # time-averaged 
+            proc="_avg"
+        elif meta['attrs']['stepType'] == 'min': # min
+            proc="_min"
+        elif meta['attrs']['stepType'] == 'max': # max
+            proc="_max"
+        else:
+            proc=""
+
+        # constant fields (surface geopotential & lsm)
+        if ( (meta['attrs']['paramId'] == 129) and (meta["level"] == 0) ) or (meta['attrs']['paramId'] == 172):
+            dim=2
+            proc="_const"
+            
+        # check for model grid
+        if meta['attrs']['gridType'] == "reduced_ll": # reduced lat-lon grid (wave model native, pre 49r1)
+            grid='_ll'
+        else:
+            grid=""
+
+        outstr = 'atm%id%s%s' % (dim,grid,proc)
+        return outstr
+    
 class EnsembleMagician(IFSMagician):
     varkeys = "param", "levtype"
     dimkeys = "posix_time", "level", "member"
@@ -163,5 +311,7 @@ class EnsembleMagician(IFSMagician):
 MAGICIANS = {
     "monsoon": Magician,
     "ifs": IFSMagician,
+    "ifseerie": IFSMagicianEERIE,
+    "ifseeriev1": IFSMagicianEERIE_v1,
     "enfo": EnsembleMagician,
 }

--- a/gribscan/magician.py
+++ b/gribscan/magician.py
@@ -153,6 +153,14 @@ class IFSMagicianEERIE(IFSMagician):
     # dimkeys = "referenceTime", "level", "realization"
     dimkeys = "posix_time", "level", "realization"
 
+    def globals_hook(self, global_attrs):
+        history = global_attrs.get("history", "")
+        if len(history) > 0 and not history.endswith("\n"):
+            history = history + "\r\n"
+        history += "🪄🧙‍♂️🔮 magic dataset assembly provided by gribscan.IFSMagicianEERIE\r\n"
+        history += "created {today}\r\n".format(today=np.datetime64('today'))
+        return {**global_attrs, "history": history}
+
     def coords_hook(self, name, coords):
         dims = [name]
         attrs = {}

--- a/gribscan/tools.py
+++ b/gribscan/tools.py
@@ -42,13 +42,22 @@ def create_index():
         default=1,
         nargs="?",
     )
+    parser.add_argument(
+        "-l",
+        "--lean_towards",
+        help="Convention for time alignment for TimeRange",
+        type=str,
+        default='end',
+        nargs="?",
+    )
     args = parser.parse_args()
 
     logging.basicConfig()
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
-    mapfunc = partial(gribscan.write_index, outdir=args.outdir, force=args.force)
+    mapfunc = partial(gribscan.write_index, outdir=args.outdir, force=args.force, lean_towards=args.lean_towards)
+    # mapfunc = partial(gribscan.write_index, outdir=args.outdir, force=args.force)
     with mp.Pool(args.nprocs) as pool:
         pool.map(mapfunc, args.sources)
 

--- a/gribscan/tools.py
+++ b/gribscan/tools.py
@@ -45,7 +45,7 @@ def create_index():
     parser.add_argument(
         "-l",
         "--lean_towards",
-        help="Convention for time alignment for TimeRange",
+        help="Convention for time alignment for TimeRange: start/end/mid, default: end",
         type=str,
         default='end',
         nargs="?",

--- a/gribscan/tools.py
+++ b/gribscan/tools.py
@@ -57,7 +57,6 @@ def create_index():
         logging.getLogger().setLevel(logging.DEBUG)
 
     mapfunc = partial(gribscan.write_index, outdir=args.outdir, force=args.force, lean_towards=args.lean_towards)
-    # mapfunc = partial(gribscan.write_index, outdir=args.outdir, force=args.force)
     with mp.Pool(args.nprocs) as pool:
         pool.map(mapfunc, args.sources)
 


### PR DESCRIPTION
This PR is meant to make two improvements:
1. Build on existing functionality to improve handling of time-processed output.
2. Introduce Magician for EERIE project.

1. Build on existing functionality to improve handling of time-processed output: 
    The function get_time_offset contains an argument "lean_towards" with default (and only) option "end" which moves the timestamp of a stepRange field to the end of the interval (mean over January 2020 is at 2020-02-01 00:00). This is slightly inconvenient as the mean over January will be associated with February. Now get_time_offset supports three options to "lean_towards" (still defaulting to "end" to retain existing behaviour): 
    - "start": use offset=0, timestamp is at the beginning of the period (mean over January 2020 is at 2020-01-01 00:00)
    - "end" (as before): use offset=<length_of_period>, timestamp is at the end of the period (mean over January 2020 is at 2020-02-01 00:00)
    - "mid": timestamp is *near* the center of the period, depending on its length. This is achieved by adding *less* than length_of_period.
      - annual: timestamp is on July 1st, 12:00 
      - monthly: timestamp is on the 15th, 12:00
      - daily: timestamp is at 12:00
      - sub-daily: timestamp is at the center of the period (e.g. 6-hourly means for the period 00:00-06:00 is at 03:00)

2. Introduce Magician for EERIE project:
    - introduces ensemble "realization" axis (for "ed" class requires eccodes >= 2.36.1). Required writing "realisation" in scan_gribfile.
        Only appears if processing more than one member.
    - split jsons files by type: 
        - Time-processing by stepType (instant/accum/avg/min/max). 
        - Constant fields of surface geopotential & land-sea mask go into "atm2d_const.json".
        - Output on wave model (WAM) native grid (pre 49r1) goes into separate jsons with additional "_ll" suffix.
    - This is intended to be used together with the new get_time_offset option "mid", 
        such that stepRange-based variables are now located towards the CENTER of the stepRange.

Happy to hear any feedback!