### PR TITLE
Add support for spherical harmonics (sh) grids

### DIFF
--- a/gribscan/gridutils.py
+++ b/gribscan/gridutils.py
@@ -88,6 +88,15 @@ class HEALPix(GribGrid):
         return {"lon": lons, "lat": lats}
 
 
+class SphericalHarmonics(GribGrid):
+    gridType = "sh"
+    params = []
+
+    @classmethod
+    def compute_coords(cls):
+        return {}
+
+
 grids = {g.gridType: g for g in GribGrid._subclasses}
 
 


### PR DESCRIPTION
Adding a `GribGrid` subclass `SphericalHarmonics` to support "sh" grids.
This closes #55 