### PR TITLE
add configuration to .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,3 +17,4 @@ python:
 
 sphinx:
   fail_on_warning: true
+  configuration: docs/source/conf.py


### PR DESCRIPTION
Readthedocs projects without an explicit `configuration` will [soon be deprecated](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/).