### PR TITLE
More robust auto-determination of index file path

### DIFF
--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -357,7 +357,11 @@ def write_index(gribfile, idxfile=None, outdir=None, force=False):
         outdir = p.parent
 
     if idxfile is None:
-        idxfile = pathlib.Path(outdir) / (p.stem + ".index")
+        # Replace GRIB suffixes but append to all others (e.g. `fcst_phy2m.202410`).
+        suffix_map = {s: ".index" for s in (".grib", ".grb", ".grib2", ".grb2")}
+        idxfile = pathlib.Path(outdir) / (
+            p.with_suffix(suffix_map.get(p.suffix, p.suffix + ".index")).name
+        )
 
     if idxfile.exists() and not force:
         raise FileExistsError(f"Index file {idxfile} already exists!")


### PR DESCRIPTION
GRIB files often do not have unique file extensions, e.g. `fcst_phy2m.202411`. In these cases, the current implementation would result in successive index overwrites. This PR makes the automatic determination of the index file path based on the GRIB file path more robust by replacing only GRIB-related suffixes and appending to all others.