### PR TITLE
Fix parsing of (yet another) forecast time

### DIFF
--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -278,13 +278,16 @@ def get_time_offset(gribmessage, lean_towards="end"):
                 int(gribmessage.get("indicatorOfUnitOfTimeRange", 255))
             ]
             offset += gribmessage.get("forecastTime", 0) * unit
-        if options["timeRange"] and lean_towards == "end":
+        if options["timeRange"]:
             unit = time_range_units[
                 int(gribmessage.get("indicatorOfUnitOfTimeRange", 255))
             ]
             length = gribmessage.get("lengthOfTimeRange", 0)
             if isinstance(length, np.ndarray):
-                length = int(length[-1])
+                if lean_towards == "start":
+                    length = int(length[0])
+                elif lean_towards == "end":
+                    length = int(length[-1])
             offset += length * unit
     return offset
 

--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -282,7 +282,10 @@ def get_time_offset(gribmessage, lean_towards="end"):
             unit = time_range_units[
                 int(gribmessage.get("indicatorOfUnitOfTimeRange", 255))
             ]
-            offset += gribmessage.get("lengthOfTimeRange", 0) * unit
+            length = gribmessage.get("lengthOfTimeRange", 0)
+            if isinstance(length, np.ndarray):
+                length = int(length[-1])
+            offset += length * unit
     return offset
 
 


### PR DESCRIPTION
This PR fixes the calculation of the POSIX timestamp in situations where there is a time interval for the forecasted time. This combination was apparently not covered before.

There may be a cleaner way to handle this, but the current fix is consistent with other implementations in `gribscan` so far. We may consider switching to proper `time_bnds` at some point, but that seems beyond the scope of this PR.