### PR TITLE
Specify non-existing filters as None instead of empty list

### DIFF
--- a/gribscan/gribscan.py
+++ b/gribscan/gribscan.py
@@ -537,7 +537,7 @@ def build_refs(messages, global_attrs, coords, varinfo, magician):
                 "compressor": {"id": "gribscan.rawgrib"},
                 "dtype": info["dtype"],
                 "fill_value": info["attrs"].get("missingValue", 9999),
-                "filters": [],
+                "filters": None,
                 "order": "C",
                 "zarr_format": 2,
             }
@@ -561,7 +561,7 @@ def build_refs(messages, global_attrs, coords, varinfo, magician):
                     "compressor": compressor_id,
                     "dtype": cs.dtype.str,
                     "fill_value": None,
-                    "filters": [],
+                    "filters": None,
                     "order": "C",
                     "shape": list(cs.shape),
                     "zarr_format": 2,


### PR DESCRIPTION
Specifying non-existing filters as an empty list apparently violates the Zarr v2 specs and caused a warning in Xarray. This PR fixes the behaviour by setting `filters=None`.